### PR TITLE
⬆️ 🔧 update tailwind and enable jit

### DIFF
--- a/fragments/tailwindcss/blueprint.js
+++ b/fragments/tailwindcss/blueprint.js
@@ -12,6 +12,7 @@ module.exports = {
         },
 
         tailwindcss: {
+            mode: "'jit'",
             darkMode: "'class'",
             future: {
                 removeDeprecatedGapUtilities: "true",

--- a/fragments/tailwindcss/package.json
+++ b/fragments/tailwindcss/package.json
@@ -3,6 +3,6 @@
     "autoprefixer": "^10.2.3",
     "cssnano": "^4.1.10",
     "postcss-import": "^13.0.0",
-    "tailwindcss": "^2.0.2"
+    "tailwindcss": "^2.1.1"
   }
 }


### PR DESCRIPTION
This updates the tailwind to the latest `2.1` version and enables the new `jit` feature by default.

### modified fragments
- tailwindcss