### PR TITLE
👷 ✅  adjust node version at ci / reconfigure tests [experimental]

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 15.x]
+        node-version: [14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ const { spawnSync, spawn, execFileSync, execSync } = require('child_process')
 
 
 const fragmentCombos = [
-    'rollup,auth,content,i18n,milligram,markdown,spank',
+    'rollup',
     'vite',
     'nollup',
     'snowpack'


### PR DESCRIPTION
## adjust node version at ci
- I only included the latest node versions into the GitHub action

## reconfigure tests
Here I minified the test cases to the bundler fragments we're actually supporting.

> This PR has some **experimental** touch, because when I ran the actions locally there were completed with a failure which can be assigned to my local environment