### PR TITLE
Update and rename svite.md to vite.md

### DIFF
--- a/fragments/vite/template/src/pages/guide/svite.md
+++ b/fragments/vite/template/src/pages/guide/svite.md
@@ -1,3 +1,0 @@
-### Svite
-
-Lightning fast (no)bundler. The default bundler for sveltekit.

--- a/fragments/vite/template/src/pages/guide/vite.md
+++ b/fragments/vite/template/src/pages/guide/vite.md
@@ -1,0 +1,3 @@
+### Vite
+
+Lightning fast (no)bundler. Server for modules in development, uses Rollup for production builds. Rollup plugins compatible.


### PR DESCRIPTION
Guide was left out in last fragment change from Svite to Vite