### PR TITLE
Auth fragment styling

### DIFF
--- a/fragments/auth/template/src/components/Auth/Link.svelte
+++ b/fragments/auth/template/src/components/Auth/Link.svelte
@@ -1,33 +1,33 @@
 <script>
-    import { user, authenticating } from "./store";
-    import { url } from "@roxi/routify";
+  import { user, authenticating } from "./store";
+  import { url } from "@roxi/routify";
 </script>
 
 <ul>
-    <li>
-        {#if $authenticating}
-            authenticating...
-        {:else if $user}
-            <a href={$url("/user")}>{$user.username}</a>
-        {:else}
-            <a href={$url("/login")}>Login</a>
-        {/if}
-    </li>
-    <li>
-        <a href={$url("/protected")}>Go to protected pages</a>
-    </li>
+  <li>
+    {#if $authenticating}
+      authenticating...
+    {:else if $user}
+      <a href={$url("/user")}>{$user.username}</a>
+    {:else}
+      <a href={$url("/login")}>Login</a>
+    {/if}
+  </li>
+  <li>
+    <a href={$url("/protected")}>Go to protected pages</a>
+  </li>
 </ul>
 
 <style>
-    ul.nested {
-        /* display: none; */
-        position: absolute;
-    }
-    ul.root:hover ul.nested {
-        display: block;
-    }
-    li {
-        margin: 1rem;
-        list-style: none;
-    }
+  ul.nested {
+    /* display: none; */
+    position: absolute;
+  }
+  ul.root:hover ul.nested {
+    display: block;
+  }
+  li {
+    margin: 1rem;
+    list-style: none;
+  }
 </style>

--- a/fragments/auth/template/src/components/Auth/Link.svelte
+++ b/fragments/auth/template/src/components/Auth/Link.svelte
@@ -1,29 +1,33 @@
 <script>
-  import { user, authenticating } from "./store";
-  import { url } from "@roxi/routify";
+    import { user, authenticating } from "./store";
+    import { url } from "@roxi/routify";
 </script>
+
 <ul>
-  <li>
-    {#if $authenticating}
-      authenticating...
-    {:else if $user}
-      <a href={$url("/user")}>{$user.username}</a>
-    {:else}
-      <a href={$url("/login")}>Login</a>
-    {/if}
-  </li>
+    <li>
+        {#if $authenticating}
+            authenticating...
+        {:else if $user}
+            <a href={$url("/user")}>{$user.username}</a>
+        {:else}
+            <a href={$url("/login")}>Login</a>
+        {/if}
+    </li>
+    <li>
+        <a href={$url("/protected")}>Go to protected pages</a>
+    </li>
 </ul>
 
 <style>
-  ul.nested {
-    /* display: none; */
-    position: absolute;
-  }
-  ul.root:hover ul.nested {
-    display: block;
-  }
-  li {
-    margin-left: 6px;
-    list-style: none;
-  }
+    ul.nested {
+        /* display: none; */
+        position: absolute;
+    }
+    ul.root:hover ul.nested {
+        display: block;
+    }
+    li {
+        margin: 1rem;
+        list-style: none;
+    }
 </style>

--- a/fragments/auth/template/src/components/Auth/Login.svelte
+++ b/fragments/auth/template/src/components/Auth/Login.svelte
@@ -1,28 +1,28 @@
 <script>
-    import { login, authenticating, user } from "./store.js";
-    let username = "user@example.com";
-    let password = "pass";
+  import { login, authenticating, user } from "./store.js";
+  let username = "user@example.com";
+  let password = "pass";
 
-    const handleSubmit = () => login(username, password);
+  const handleSubmit = () => login(username, password);
 </script>
 
 <div class="container">
-    <h3>Login</h3>
-    <form on:submit|preventDefault={handleSubmit}>
-        <input type="text" bind:value={username} />
-        <input type="password" bind:value={password} />
-        {#if !$authenticating && !$user}
-            <input type="submit" />
-        {:else}
-            authenticating...
-        {/if}
-    </form>
+  <h3>Login</h3>
+  <form on:submit|preventDefault={handleSubmit}>
+    <input type="text" bind:value={username} />
+    <input type="password" bind:value={password} />
+    {#if !$authenticating && !$user}
+      <input type="submit" />
+    {:else}
+      authenticating...
+    {/if}
+  </form>
 </div>
 
 <style>
-    input {
-        color: black;
-        padding: 6px;
-        border-radius: 5px;
-    }
+  input {
+    color: black;
+    padding: 6px;
+    border-radius: 5px;
+  }
 </style>

--- a/fragments/auth/template/src/components/Auth/Login.svelte
+++ b/fragments/auth/template/src/components/Auth/Login.svelte
@@ -1,20 +1,28 @@
 <script>
-  import { login, authenticating, user } from "./store.js";
-  let username = "user@example.com";
-  let password = "pass";
+    import { login, authenticating, user } from "./store.js";
+    let username = "user@example.com";
+    let password = "pass";
 
-  const handleSubmit = () => login(username, password);
+    const handleSubmit = () => login(username, password);
 </script>
 
 <div class="container">
-  <h3>Login</h3>
-  <form on:submit|preventDefault={handleSubmit}>
-    <input type="text" bind:value={username} />
-    <input type="password" bind:value={password} />
-    {#if !$authenticating && !$user}
-      <input type="submit" />
-    {:else}
-      authenticating...
-    {/if}
-  </form>
+    <h3>Login</h3>
+    <form on:submit|preventDefault={handleSubmit}>
+        <input type="text" bind:value={username} />
+        <input type="password" bind:value={password} />
+        {#if !$authenticating && !$user}
+            <input type="submit" />
+        {:else}
+            authenticating...
+        {/if}
+    </form>
 </div>
+
+<style>
+    input {
+        color: black;
+        padding: 6px;
+        border-radius: 5px;
+    }
+</style>

--- a/fragments/auth/template/src/pages/protected/_reset.svelte
+++ b/fragments/auth/template/src/pages/protected/_reset.svelte
@@ -1,48 +1,66 @@
 <script>
-  import Login from "../../components/Auth/Login.svelte";
-  import { authenticating, user, logout } from "../../components/Auth/store.js";
-  import { url, ready } from "@roxi/routify";
+    import Login from "../../components/Auth/Login.svelte";
+    import { authenticating, user, logout } from "../../components/Auth/store.js";
+    import { url, ready } from "@roxi/routify";
 
-  /**
-   * We don't want SSR for the content of protected pages. If we did,
-   * `$ready()` should be called if the user failed to authenticate.
-   * Otherwise Routify will wait indefinitely for `<slot />` to load.
-   * */
-  $: if (!$authenticating && !$user) $ready();
+    /**
+     * We don't want SSR for the content of protected pages. If we did,
+     * `$ready()` should be called if the user failed to authenticate.
+     * Otherwise Routify will wait indefinitely for `<slot />` to load.
+     * */
+    $: if (!$authenticating && !$user) $ready();
 </script>
 
 <div class="protected">
-  <a href={$url("/")}>Go back</a>
-  <h1>
-    Protected module {#if $user}<button on:click={logout}>logout</button>{/if}
-  </h1>
-  <main class="container">
-    {#if $user}
-      <slot />
-    {:else if $authenticating}
-      <h2>authenticating...</h2>
-    {:else}
-      <Login />
-    {/if}
-  </main>
+    <div class="wrapper">
+        <nav>
+            <a href={$url("/")}>Go back</a>
+            {#if $user}<button on:click={logout}>logout</button>{/if}
+        </nav>
+        <h1>Protected module</h1>
+        <main class="container">
+            {#if $user}
+                <slot />
+            {:else if $authenticating}
+                <h2>authenticating...</h2>
+            {:else}
+                <Login />
+            {/if}
+        </main>
+    </div>
 </div>
 
 <style>
-  .protected {
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    background: black;
-  }
-  * :global(*) {
-    color: white;
-  }
-  * :global(code) {
-    color: initial;
-  }
-  button {
-    position: absolute;
-    right: 16px;
-    top: 16px;
-  }
+    .protected {
+        position: absolute;
+        height: calc(100% - 16px);
+        width: calc(100% - 16px);
+        background: black;
+    }
+
+    .wrapper {
+        padding: 2rem;
+    }
+
+    * :global(*) {
+        color: white;
+    }
+    * :global(code) {
+        color: yellow;
+        font-weight: bold;
+    }
+
+    nav {
+        display: flex;
+        justify-content: space-between;
+        height: 2rem;
+        align-items: center;
+    }
+
+    button {
+        padding: 8px;
+        color: black;
+        border-radius: 6px;
+        cursor: pointer;
+    }
 </style>

--- a/fragments/auth/template/src/pages/protected/_reset.svelte
+++ b/fragments/auth/template/src/pages/protected/_reset.svelte
@@ -1,66 +1,66 @@
 <script>
-    import Login from "../../components/Auth/Login.svelte";
-    import { authenticating, user, logout } from "../../components/Auth/store.js";
-    import { url, ready } from "@roxi/routify";
+  import Login from "../../components/Auth/Login.svelte";
+  import { authenticating, user, logout } from "../../components/Auth/store.js";
+  import { url, ready } from "@roxi/routify";
 
-    /**
-     * We don't want SSR for the content of protected pages. If we did,
-     * `$ready()` should be called if the user failed to authenticate.
-     * Otherwise Routify will wait indefinitely for `<slot />` to load.
-     * */
-    $: if (!$authenticating && !$user) $ready();
+  /**
+   * We don't want SSR for the content of protected pages. If we did,
+   * `$ready()` should be called if the user failed to authenticate.
+   * Otherwise Routify will wait indefinitely for `<slot />` to load.
+   * */
+  $: if (!$authenticating && !$user) $ready();
 </script>
 
 <div class="protected">
-    <div class="wrapper">
-        <nav>
-            <a href={$url("/")}>Go back</a>
-            {#if $user}<button on:click={logout}>logout</button>{/if}
-        </nav>
-        <h1>Protected module</h1>
-        <main class="container">
-            {#if $user}
-                <slot />
-            {:else if $authenticating}
-                <h2>authenticating...</h2>
-            {:else}
-                <Login />
-            {/if}
-        </main>
-    </div>
+  <div class="wrapper">
+    <nav>
+      <a href={$url("/")}>Go back</a>
+      {#if $user}<button on:click={logout}>logout</button>{/if}
+    </nav>
+    <h1>Protected module</h1>
+    <main class="container">
+      {#if $user}
+        <slot />
+      {:else if $authenticating}
+        <h2>authenticating...</h2>
+      {:else}
+        <Login />
+      {/if}
+    </main>
+  </div>
 </div>
 
 <style>
-    .protected {
-        position: absolute;
-        height: calc(100% - 16px);
-        width: calc(100% - 16px);
-        background: black;
-    }
+  .protected {
+    position: absolute;
+    height: calc(100% - 16px);
+    width: calc(100% - 16px);
+    background: black;
+  }
 
-    .wrapper {
-        padding: 2rem;
-    }
+  .wrapper {
+    padding: 2rem;
+  }
 
-    * :global(*) {
-        color: white;
-    }
-    * :global(code) {
-        color: yellow;
-        font-weight: bold;
-    }
+  * :global(*) {
+    color: white;
+  }
+  * :global(code) {
+    color: yellow;
+    font-weight: bold;
+  }
 
-    nav {
-        display: flex;
-        justify-content: space-between;
-        height: 2rem;
-        align-items: center;
-    }
+  nav {
+    display: flex;
+    justify-content: space-between;
+    height: 2rem;
+    align-items: center;
+  }
 
-    button {
-        padding: 8px;
-        color: black;
-        border-radius: 6px;
-        cursor: pointer;
-    }
+  button {
+    padding: 8px;
+    color: black;
+    border-radius: 6px;
+    cursor: pointer;
+  }
 </style>


### PR DESCRIPTION
I did what I could with styling to not change the whole concept. Protected page was set up with inverted theme and some global styles also messed with inputs. 

We might think of a global css which can be deleted or updated on demand and each fragment would contribute to initially. It's a simple and quick way to replace styling in general on a new project.

Added a link to `/protected` route as there was none.